### PR TITLE
feat: allow setting of a callback url for when pipeline finished

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+CALLBACK_URL ?= https://eosv8e8x84ccn8d.m.pipedream.net?stage=completed
 CONFIG_FILE ?= ./examples/basic/config.yaml
 LOG_LEVEL ?= debug
 SERVER_ADDRESS ?= http://localhost:3000
@@ -10,5 +11,5 @@ run:
 .PHONY: run
 
 trigger:
-	curl -iL -X POST ${SERVER_ADDRESS}${WEBHOOK}
+	curl -iL -X POST -H "X-Callback-URL: ${CALLBACK_URL}" ${SERVER_ADDRESS}${WEBHOOK}
 .PHONY: trigger

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 * [Getting Started](#getting-started)
   * [Including Dynamic Data](#including-dynamic-data)
 * [Kubernetes](#kubernetes)
+* [Triggers](#triggers)
+  * [HTTP](#http)
 * [Project Status](#project-status)
 * [Contributing](#contributing)
   * [Open in Gitpod](#open-in-gitpod)
@@ -155,6 +157,42 @@ spec:
     - protocol: TCP
       port: 3000
       targetPort: 3000
+```
+
+## Triggers
+
+In pipeline must be started by a trigger
+
+### HTTP
+
+This runs on `POST:/webhook/:name`. Once it's been accepted, it returns an HTTP
+202 Accepted status. The pipeline will run asynchronously after that.
+
+If you pass a URL in via the `X-Callback-URL` header, this will be called once
+the pipeline has run successfully. This will be sent as an HTTP `POST` call with
+information about the pipeline including all the data received from the jobs in
+the pipeline.
+
+```json
+{
+  "name": "\<name\>",
+  "response": {
+    "\<stage-name\>": {
+      "\<job-name\>": {
+        "status": 200, // HTTP status code
+        "headers": {}, // Key/value pairs of headers received
+        "body": {} // Key/value pairs of body received
+      }
+    }
+  }
+  "stages": [
+    "\<stage-name\>"
+  ],
+  "executionTime": {
+    "start": "2023-01-05T12:00:00.000Z", // Start time
+    "total": 123 // Time in milliseconds
+  }
+}
 ```
 
 ## Project Status

--- a/pkg/pipeline/duration.go
+++ b/pkg/pipeline/duration.go
@@ -1,0 +1,15 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type Duration struct {
+	time.Duration
+}
+
+// Send out in nanoseconds for cross-compatability
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.Milliseconds())
+}

--- a/pkg/pipeline/jobs.go
+++ b/pkg/pipeline/jobs.go
@@ -37,7 +37,7 @@ func (j *Job) Exec(p *Pipeline) (*Result, error) {
 }
 
 type Result struct {
-	Status  int
-	Headers http.Header
-	Body    map[string]any
+	Status  int            `json:"status"`
+	Headers http.Header    `json:"headers"`
+	Body    map[string]any `json:"body"`
 }

--- a/pkg/server/triggers.go
+++ b/pkg/server/triggers.go
@@ -1,20 +1,61 @@
 package server
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/mrsimonemms/conveyor-belt/pkg/config"
 	"github.com/mrsimonemms/conveyor-belt/pkg/pipeline"
+	logger "github.com/mrsimonemms/gin-structured-logger"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
+
+func TriggerCallback(url string, p *pipeline.Pipeline, l zerolog.Logger) error {
+	lg := l.With().Str("url", url).Logger()
+
+	lg.Debug().Msg("Triggering pipeline completion callback")
+	client := http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	data, err := json.Marshal(p)
+	if err != nil {
+		lg.Error().Err(err).Msg("Failed to decode pipeline to JSON")
+		return err
+	}
+
+	if _, err := client.Post(url, "application/json", bytes.NewBuffer(data)); err != nil {
+		lg.Error().Err(err).Msg("Failed to send completion callback")
+		return err
+	}
+
+	lg.Debug().Msg("Completion callback triggered successfully")
+	return nil
+}
 
 func webhookHandler(p *pipeline.Pipeline) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		// Run as async go routine
 		go func() {
-			_ = p.Run()
+			completionAction := make([]pipeline.CompletionAction, 0)
+			// If x-callback-url exists, trigger a POST to the callback with the collated data
+			if callbackUrl := ctx.GetHeader("x-callback-url"); callbackUrl != "" {
+				completionAction = append(completionAction, func(p *pipeline.Pipeline, l zerolog.Logger) {
+					// For HTTP, don't use the received logger, use the HTTP context one
+					_ = TriggerCallback(callbackUrl, p, logger.Get(ctx).With().Logger())
+				})
+			}
+
+			completionAction = append(completionAction, func(p *pipeline.Pipeline, l zerolog.Logger) {
+				logger.Get(ctx).Debug().Msg("Pipeline run completed")
+			})
+
+			_ = p.Run(completionAction...)
 		}()
 
 		ctx.Writer.WriteHeader(http.StatusAccepted)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Allows an `x-callback-url` to be sent to an HTTP trigger which will send a final job with all the information received by the pipeline.

## How to test
<!-- Provide steps to test this PR -->
Run `make trigger`